### PR TITLE
Add Windows Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ apt get install librdkafka-dev
 brew install librdkafka
 ```
 
+#### Windows
+
+- Install RTools (i.e. using `installr::install.rtools()`)
+- Download the librdkafka binaries and header files using the rtools bash / msys2 command line: `pacman -Sy mingw-w64-ucrt-x86_64-librdkafka`
+- Add the path to the msys2 binaries to your windows PATH (settings -> edit environment variables for your account)
+- (Potentially) change directory to msys2 in the Makevars.win file if it is not located at `C:/rtools43/ucrt64/`
+
 ## (Integration) Tests
 
 We are using trivup to spin up a local kafka cluster for testing

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,0 +1,2 @@
+PKG_CXXFLAGS = -I/C/rtools43/ucrt64/include
+PKG_LIBS = -L/C/rtools43/ucrt64/lib -lrdkafka++


### PR DESCRIPTION
Windows support added with some manual effort (i.e. changing paths in the Makevars.win file). When we publish the package to CRAN we need to refactor the windows bit anyway.